### PR TITLE
Fix: 비밀번호 찾기 시 응답에 memberId 추가

### DIFF
--- a/src/main/java/com/WalkiePaw/presentation/domain/mail/EmailController.java
+++ b/src/main/java/com/WalkiePaw/presentation/domain/mail/EmailController.java
@@ -2,6 +2,7 @@ package com.WalkiePaw.presentation.domain.mail;
 
 import com.WalkiePaw.domain.mail.service.MailService;
 import com.WalkiePaw.presentation.domain.mail.dto.EmailAuthRequest;
+import com.WalkiePaw.presentation.domain.mail.dto.EmailAuthResponse;
 import com.WalkiePaw.presentation.domain.mail.dto.EmailSendRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +26,8 @@ public class EmailController {
     }
 
     @PostMapping("/authCheck")
-    public ResponseEntity<Void> AuthCheck(@RequestBody @Valid final EmailAuthRequest request) {
-        Boolean Checked = mailService.CheckAuthNum(request.getEmail(), request.getAuthNum());
-        if (Checked) {
-            return ResponseEntity.ok().build();
-        } else {
-            throw new NullPointerException("뭔가 잘못!");
-        }
+    public ResponseEntity<EmailAuthResponse> AuthCheck(@RequestBody @Valid final EmailAuthRequest request) {
+        return ResponseEntity.ok(mailService.CheckAuthNum(request.getEmail(), request.getAuthNum()));
+
     }
 }

--- a/src/main/java/com/WalkiePaw/presentation/domain/mail/dto/EmailAuthResponse.java
+++ b/src/main/java/com/WalkiePaw/presentation/domain/mail/dto/EmailAuthResponse.java
@@ -1,0 +1,11 @@
+package com.WalkiePaw.presentation.domain.mail.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailAuthResponse {
+    private Integer memberId;
+    private String result;
+}


### PR DESCRIPTION
- 만약 db에 해당하는 메일이 있으면 memberId를 추가하여 주고 db에 해당하는 메일이 없으면 memberId를 null로 줌

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
비밀번호 찾기 시 응답에 memberId 추가


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
